### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ not thoroughly tested yet.
 However, I am quite satisfied with how things work at the moment; I do not expect any radical API/usage changes.
 This means that this project can be considered fairly stable API/usage-wise.
 
-Ideas, critisism, comments, code contributions are all welcome!
+Ideas, criticism, comments, code contributions are all welcome!


### PR DESCRIPTION
@nikospara, I've corrected a typographical error in the documentation of the [require-lazy](https://github.com/nikospara/require-lazy) project. Specifically, I've changed critisism to criticism. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
